### PR TITLE
chore: add empty build_depends.repos

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -1,0 +1,1 @@
+repositories:


### PR DESCRIPTION
This PR fixes build error in https://github.com/tier4/lexus_description.iv/runs/5098453366?check_suite_focus=true  .
This is because build_depends.repos does not exist.
build_depens.repos has no repositories  since this package has no dependencies.