### PR TITLE
ci: update settings of sync-files

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -1,22 +1,19 @@
 - repository: autowarefoundation/autoware
   files:
     - source: .github/dependabot.yaml
+    - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-differential.yaml
-    - source: .clang-format
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml
     - source: .pre-commit-config-optional.yaml
     - source: .prettierignore
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
-    - source: CPPLINT.cfg
     - source: setup.cfg
 
 - repository: autowarefoundation/autoware_common
   files:
     - source: .github/workflows/build-and-test.yaml
     - source: .github/workflows/build-and-test-differential.yaml
-    - source: .github/workflows/pre-commit.yaml
-    - source: .pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,16 +77,4 @@ repos:
             flake8-quotes,
           ]
 
-  - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
-    hooks:
-      - id: clang-format
-
-  - repo: https://github.com/cpplint/cpplint
-    rev: 1.5.5
-    hooks:
-      - id: cpplint
-        args: [--quiet]
-        exclude: .cu
-
 exclude: .svg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(lexus_description)
 add_compile_options(-std=c++14)
 
 find_package(ament_cmake_auto REQUIRED)
-find_package(xacro REQUIRED)
 
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION
Removed clang-format and cpplint.
I also stopped syncing pre-commit-config.yaml because it will re-add cpplint and clang-format.

The reason why I changed the sync source of `pre-commit` workflow is because `autoware_common` syncs from `autoware`.
https://github.com/autowarefoundation/autoware_common/blob/eb6029fb0144871a6df76b89298081bb7e08d708/.github/sync-files.yaml#L8