### PR TITLE
fix(lexus_description): fix xacro deprecated usage

### DIFF
--- a/lexus_description/urdf/vehicle.xacro
+++ b/lexus_description/urdf/vehicle.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- load parameter -->
-  <xacro:property name="vehicle_info" value="${load_yaml('$(find lexus_description)/config/vehicle_info.param.yaml')}"/>
+  <xacro:property name="vehicle_info" value="${xacro.load_yaml('$(find lexus_description)/config/vehicle_info.param.yaml')}"/>
 
   <!-- vehicle body -->
   <link name="base_link">


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

In order to remove the multiple warning messages `warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.` when launching autoware.