### PR TITLE
fix: set enable_road_slope_simulation to true

### DIFF
--- a/lexus_description/config/simulator_model.param.yaml
+++ b/lexus_description/config/simulator_model.param.yaml
@@ -6,6 +6,7 @@
     initialize_source: "INITIAL_POSE_TOPIC"
     timer_sampling_time_ms: 25
     add_measurement_noise: False
+    enable_road_slope_simulation: True
     vel_lim: 50.0
     vel_rate_lim: 7.0
     steer_lim: 1.0


### PR DESCRIPTION
Autoware側では勾配を考慮するがsimple planning simulatorでは勾配を考慮しない設定となっており、勾配での発進時に停止し続けてしまっていた
どちらも勾配を考慮するように修正

https://tier4.atlassian.net/browse/RT1-4804
https://tier4.atlassian.net/browse/RT1-4526
に対する修正